### PR TITLE
ISMN weblink updated at index.Rmd: L108

### DIFF
--- a/index.Rmd
+++ b/index.Rmd
@@ -105,7 +105,7 @@ Some existing soil Observations and Measurements (O&M) soil data initiatives inc
   - [**Global soil macrofauna database**](http://macrofauna.earthworms.info/),\
   - [**Global soil respiration database (SRDB)**](https://github.com/bpbond/srdb),\
   - [**International Soil Modeling Consortium (ISMC)**](https://soil-modeling.org),\
-  - [**International Soil Moisture Network**](https://ismn.geo.tuwien.ac.at/en/),\
+  - [**International Soil Moisture Network**](https://ismn.earth/en/),\
   - [**International Soil Radiocarbon Database (ISRaD)**](https://soilradiocarbon.org),\
   - [**International Soil Carbon Network (ISCN)**](http://iscn.fluxdata.org/),\
   - [**LandPKS project**](http://portal.landpotential.org/#/landpksmap),\


### PR DESCRIPTION
Saw that old ISMN weblink (which is not working again) for the former host was on the index page. Weblink now update to current host url.